### PR TITLE
Deposit protocol changes

### DIFF
--- a/src/Hydra/Protocol/Figures/offchain-protocol.tex
+++ b/src/Hydra/Protocol/Figures/offchain-protocol.tex
@@ -15,7 +15,7 @@
 							$\hydraKeysAgg \gets \msCombVK(\hydraKeys^{setup})$ \;
 							$\cardanoKeys \gets \cardanoKeys^{setup}$\;
 							$\Tcontest \gets \Tcontest^{setup}$ \;
-							\red{$\Tdeposit \gets \Tdeposit^{setup}$ \;}
+							$\Tdeposit \gets \Tdeposit^{setup}$ \;
 							$\PostTx{}~(\mtxInit, \nop, \hydraKeysAgg,\cardanoKeys,\Tcontest)$ \;
 						}
 						\vspace{12pt}
@@ -53,7 +53,7 @@
 							$\hatmT \gets \emptyset$ \;
 							$\tx_\omega \gets \bot$ \;
 							% NOTE: Actually a tx id, but does not matter
-							\red{$\tx_\alpha \gets \bot$ \;}
+							$\tx_\alpha \gets \bot$ \;
 						}
 
 					\end{walgo}
@@ -76,7 +76,7 @@
 								$\hatmT \gets \hatmT \cup \{\tx\}$ \;
 								% issue snapshot if we are leader
 								\If{$\hats = \bar{\mc S}.s \land \hpLdr(\bar{\mc S}.s + 1) = i$}{
-									\Multi{} $(\hpRS,\hatv,\bar{\mc S}.s+1,\hatmT, \red{\tx_\alpha}, \tx_\omega)$ \;
+									\Multi{} $(\hpRS,\hatv,\bar{\mc S}.s+1,\hatmT \tx_\alpha,\tx_\omega)$ \;
 								}
 							}
 						}
@@ -89,42 +89,38 @@
 								$\tx_\omega \gets \tx$ \;
 								% issue snapshot if we are leader
 								\If{$\hats = \bar{\mc S}.s \land \hpLdr(\bar{\mc S}.s + 1) = i$}{
-									\Multi{} $(\hpRS,\hatv,\bar{\mc S}.s+1,\hatmT, \red{\bot}, \tx_\omega)$ \;
+									\Multi{} $(\hpRS,\hatv,\bar{\mc S}.s+1,\hatmT,\bot,\tx_\omega)$ \;
 								}
 							}
 						}
 						\vspace{12pt}
 
 						%%% REQ SN
-						\On{$(\hpRS,v,s,\underline{\tx}_{\mathsf{req}} , \red{\tx_\alpha}, \tx_\omega)$ from $\party_j$}{
+						\On{$(\hpRS,v,s,\underline{\tx}_{\mathsf{req}} ,\tx_\alpha,\tx_\omega)$ from $\party_j$}{
 							\Req{$v = \hatv ~ \land ~ s = \hats + 1 ~ \land ~ \hpLdr(s) = j$} \;
-							\Wait{$\hats = \bar{\mc S}.s \blue{~ \land ~ v = \hatv}$}{
-								\Req{$\tx_\omega = \bot ~ \red{\lor ~ \tx_\alpha = \bot}$} \;
+							% TODO: is this v = hatv really needed?
+							\Wait{$\hats = \bar{\mc S}.s ~ \land ~ v = \hatv$}{
+								\Req{$\tx_\omega = \bot ~ \lor ~ \tx_\alpha = \bot$} \;
 								\If{$\tx_\omega \neq \bot$}{
 								  % NOTE: require withdrawal to be stay consistent with last confirmed snapshot until cleared through a decrement
-								  \blue{
 								  \If{$v = \bar{\mc S}.v \land \bar{\mc S}.U_{\omega} \neq \bot$}{
 									\Req{$\bar{\mc S}.U_{\omega} = \mathsf{outputs}(\tx_\omega) $} \;
-								  }}
+								  }
 								  \Else{
 									\Req{$\bar{\mc S}.U \applytx \tx_\omega \ne \bot$} \;
 									$U_{\mathsf{active}} \gets \bar{\mc S}.U \applytx \tx_\omega \setminus \mathsf{outputs}(\tx_\omega)$ \;
 								  }
 								}
-								\If{\blue{$\tx_\alpha \neq \bot$}}{
-								  \red{
-									$\mathcal{D} \gets \mathcal{D}[\tx_\alpha]$ \;
-									\Req{$\mathcal{D}.\mathsf{status} \neq \mathsf{Expired}$} \;
-								  }
-								  \Wait{\red{$\mathcal{D}.\mathsf{status} = \mathsf{Active}$}}{
+								\If{$\tx_\alpha \neq \bot$}{
+								  $\mathcal{D} \gets \mathcal{D}[\tx_\alpha]$ \;
+								  \Req{$\mathcal{D}.\mathsf{status} \neq \mathsf{Expired}$} \;
+								  \Wait{$\mathcal{D}.\mathsf{status} = \mathsf{Active}$}{
 									% NOTE: require deposit to be stay consistent with last confirmed snapshot until cleared through an increment
-									\blue{
 									\If{$v = \bar{\mc S}.v \land \bar{\mc S}.U_{\alpha} \neq \bot$}{
-									  \Req{$\bar{\mc S}.U_{\alpha} = \red{\mathcal{D}.U} $} \;
-									}}
+									  \Req{$\bar{\mc S}.U_{\alpha} = \mathcal{D}.U $} \;
+									}
 									\Else{
-									  $U_\alpha \gets \red{\mathcal{D}.U}$ \;
-
+									  $U_\alpha \gets \mathcal{D}.U$ \;
 									  $U_{\mathsf{active}} \gets U_{\mathsf{active}} \cup  U_{\alpha}$ \;
 									}
 								  }
@@ -194,7 +190,7 @@
 
 									% issue snapshot if we are leader
 									\If{$\hpLdr(s+1) = i \land \hatmT \neq \emptyset$}{
-										\Multi{} $(\hpRS,\hatv,\bar{\mc S}.s+1, \hatmT , \red{\tx_\alpha}, \tx_\omega)$ \;
+										\Multi{} $(\hpRS,\hatv,\bar{\mc S}.s+1,\hatmT,\tx_\alpha,\tx_\omega)$ \;
 									}
 								}
 							}
@@ -202,17 +198,15 @@
 						\vspace{12pt}
 
 						%%% DEPOSIT
-					    \On{$(\mathtt{depositTx}, \red{\tx_{\alpha}, U, t_{\mathsf{created}}, t_{\mathsf{deadline}}})$ from chain}{
-						  \red{$\mathcal{D} \gets \mathcal{D} \cup (\tx_{\alpha}, \mathsf{depositObj}(U, t_{\mathsf{created}}, t_{\mathsf{deadline}}, \mathsf{Inactive}))$}
+					    \On{$(\mathtt{depositTx},\tx_{\alpha},U,t_{\mathsf{created}},t_{\mathsf{deadline}})$ from chain}{
+						  $\mathcal{D} \gets \mathcal{D} \cup (\tx_{\alpha}, \mathsf{depositObj}(U, t_{\mathsf{created}}, t_{\mathsf{deadline}}, \mathsf{Inactive}))$
 					    }
 						\vspace{12pt}
 
 						%%% RECOVER
-						\red{
 					    \On{$(\mathtt{recoverTx}, \tx_{\alpha})$ from chain}{
-						  \red{$\mathcal{D} \gets \mathcal{D} \setminus (\tx_{\alpha}, \cdot)$}
+						  $\mathcal{D} \gets \mathcal{D} \setminus (\tx_{\alpha}, \cdot)$
 					    }
-						}
 						\vspace{12pt}
 
 						%%% DECREMENT
@@ -225,13 +219,12 @@
 						%%% INCREMENT
 						\On{$(\mathtt{incrementTx}, U, v)$ from chain}{
 							$\hatv \gets v$ \;
-							$\red{\tx_\alpha \gets \bot}$\;
+							$\tx_\alpha \gets \bot$ \;
 							$\hatmL \gets \hatmL \cup U$ \;
 						}
 						\vspace{12pt}
 
 						%%% TICK
-						\red{
 						\On{$(\mathtt{tick}, t)$ from chain}{
 							\For{$D \in \mathcal{D}$}{
 							  \If{$t > D.\mathsf{deadline} - T_{\mathsf{deposit}} $}{
@@ -247,7 +240,6 @@
 									\Multi{} $(\hpRS,\hatv,\bar{\mc S}.s+1,\hatmT, \tx_\alpha, \bot)$ \;
 								}
 							}
-						}
 						}
 						\vspace{12pt}
 

--- a/src/Hydra/Protocol/Figures/offchain-protocol.tex
+++ b/src/Hydra/Protocol/Figures/offchain-protocol.tex
@@ -1,7 +1,6 @@
+\def\sfact{0.6}
 
 \begin{figure*}[t!]
-
-	\def\sfact{0.8}
 	\centering
 	\begin{algobox}{Coordinated Hydra Head}
 		\medskip
@@ -75,7 +74,7 @@
 								$\hatmT \gets \hatmT \cup \{\tx\}$ \;
 								% issue snapshot if we are leader
 								\If{$\hats = \bar{\mc S}.s \land \hpLdr(\bar{\mc S}.s + 1) = i$}{
-									\Multi{} $(\hpRS,\hatv,\bar{\mc S}.s+1,\hatmT, U_\alpha, \tx_\omega)$ \;
+									\Multi{} $(\hpRS,\hatv,\bar{\mc S}.s+1,\hatmT, \red{\tx^\#_\alpha}, \tx_\omega)$ \;
 								}
 							}
 						}
@@ -88,35 +87,32 @@
 								$\tx_\omega \gets \tx$ \;
 								% issue snapshot if we are leader
 								\If{$\hats = \bar{\mc S}.s \land \hpLdr(\bar{\mc S}.s + 1) = i$}{
-									\Multi{} $(\hpRS,\hatv,\bar{\mc S}.s+1,\hatmT, U_\alpha,\tx_\omega)$ \;
+									\Multi{} $(\hpRS,\hatv,\bar{\mc S}.s+1,\hatmT, \red{\bot}, \tx_\omega)$ \;
 								}
 							}
 						}
 						\vspace{12pt}
 
-						%%% DEPOSIT
-					    \On{$(\mathtt{depositTx}, U)$ from chain}{
-					      % FIXME: wait on chain events is a bit weird. Wait
-					      % in general feels like avoiding book keeping and
-					      % relying a lot on assumption of a perfect queue
-					      \Wait{$\tx_\omega = \bot ~ \land ~ U_{\alpha} = \emptyset$}{
-					    	$U_{\alpha} = U$ \;
-					    	% issue snapshot if we are leader
-					    	\If{$\hats = \bar{\mc S}.s \land \hpLdr(\bar{\mc S}.s + 1) = i$}{
-					    	  \Multi{} $(\hpRS,\hatv,\bar{\mc S}.s+1,\hatmT, U_\alpha, \tx_\omega)$ \;
-					    	}
-					      }
-					    }
-						\vspace{12pt}
-
 						%%% REQ SN
-						\On{$(\hpRS,v,s,\underline{\tx}_{\mathsf{req}} , U_\alpha , \tx_\omega)$ from $\party_j$}{
-							\Req{$\tx_\omega = \bot ~ \lor ~ U_\alpha = \emptyset$} \;
+						\On{$(\hpRS,v,s,\underline{\tx}_{\mathsf{req}} , \red{\tx_\alpha}, \tx_\omega)$ from $\party_j$}{
 							\Req{$v = \hatv ~ \land ~ s = \hats + 1 ~ \land ~ \hpLdr(s) = j$} \;
-							\Wait{$\hats = \bar{\mc S}.s$}{
+							\Wait{$\hats = \bar{\mc S}.s \red{~ \land ~ v = \hatv}$}{
+								\Req{$\tx_\omega = \bot ~ \red{\lor ~ \tx_\alpha = \bot}$} \;
 								\blue{
+									TODO: require consistent with $\bar{\mc S}$ \;
 									\Req{$\bar{\mc S}.U \applytx \tx_\omega \not= \bot$} \;
 									$U_{\mathsf{active}} \gets \bar{\mc S}.U \applytx \tx_\omega \setminus \mathsf{outputs}(\tx_\omega)$ \;
+								}
+								\red{
+								  \If{$\tx_\alpha \neq \bot$}{
+									$\mathcal{D} \gets \mathcal{D}[\tx_\alpha]$ \;
+                                    \Req{$\mathcal{D}.\mathsf{status} \neq \mathsf{Expired}$} \;
+                                    \Wait{$\mathcal{D}.\mathsf{status} = \mathsf{Active}$}{
+									  TODO: require consistent with $\bar{\mc S}$ \;
+									  $U_\alpha \gets \mathcal{D}.U$ \;
+                                      $U_{\mathsf{active}} \gets U_{\mathsf{active}} \cup  U_{\alpha}$ \;
+									}
+								  }
 								}
 								\Req{$U_{\mathsf{active}} \applytx \underline{\tx}_{\mathsf{req}} \not= \bot$} \;
 								$U \gets U_{\mathsf{active}} \applytx \underline{\tx}_{\mathsf{req}}$ \;
@@ -141,6 +137,7 @@
 								}
 							}
 						}
+						\vspace{12pt}
 					\end{walgo}
 				} &
 
@@ -182,26 +179,58 @@
 
 									% issue snapshot if we are leader
 									\If{$\hpLdr(s+1) = i \land \hatmT \neq \emptyset$}{
-										\Multi{} $(\hpRS,\hatv,\bar{\mc S}.s+1, \hatmT , U_\alpha, \tx_\omega)$ \;
+										\Multi{} $(\hpRS,\hatv,\bar{\mc S}.s+1, \hatmT , \red{\tx^\#_\alpha}, \tx_\omega)$ \;
 									}
 								}
 							}
 						}
 						\vspace{12pt}
 
+						%%% DEPOSIT
+					    \On{$(\mathtt{depositTx}, \red{\tx^{\#}_{\alpha}, U, t_{\mathsf{created}}, t_{\mathsf{deadline}}})$ from chain}{
+						  \red{$\mathcal{D} \gets \mathcal{D} \cup (\tx^{\#}_{\alpha}, \mathsf{depositObj}(U, t_{\mathsf{created}}, t_{\mathsf{deadline}}, \mathsf{Inactive}))$}
+					    }
+						\vspace{12pt}
+
+						%%% RECOVER
+						\red{
+					    \On{$(\mathtt{recoverTx}, \tx^{\#}_{\alpha})$ from chain}{
+						  \red{$\mathcal{D} \gets \mathcal{D} \setminus (\tx^{\#}_{\alpha}, \cdot)$}
+					    }
+						}
+						\vspace{12pt}
+
 						%%% DECREMENT
 						\On{$(\mathtt{decrementTx}, U, v)$ from chain}{
-							$\tx_{\omega} \gets \bot$ \;
 							$\hatv \gets v$ \;
+							$\tx_{\omega} \gets \bot$ \;
 						}
 						\vspace{12pt}
 
 						%%% INCREMENT
 						\On{$(\mathtt{incrementTx}, U, v)$ from chain}{
-							$\hatmL \gets \hatmL \cup U$ \;
-							$U_\alpha \gets \emptyset$\;
 							$\hatv \gets v$ \;
+							$\red{\tx^{\#}_\alpha \gets \bot}$\;
+							$\hatmL \gets \hatmL \cup U$ \;
 						}
+						\vspace{12pt}
+
+						%%% TICK
+						\red{
+						\On{$(\mathtt{tick}, t)$ from chain}{
+							\For{$D \in \mathcal{D}$}{
+							    $D.status \gets TODO$
+							}
+							\If{$\exists D \in \mathcal{D} : D.status = \mathsf{Active}$}{
+								% issue snapshot if we are leader
+								% FIXME: \tx^\#_\alpha undefined
+								\If{$\tx^\#_\alpha \neq \bot \land \tx_\omega = \bot \land \hats = \bar{\mc S}.s \land \hpLdr(\bar{\mc S}.s + 1) = i$}{
+									\Multi{} $(\hpRS,\hatv,\bar{\mc S}.s+1,\hatmT, \tx^\#_\alpha, \bot)$ \;
+								}
+							}
+						}
+						}
+						\vspace{12pt}
 
 					\end{walgo}
 				}
@@ -212,8 +241,6 @@
 \end{figure*}
 \clearpage
 \begin{figure*}[t!]
-
-	\def\sfact{0.8}
 	\begin{tabular}{c}
 		\\
 		\multicolumn{1}{l}{\line(1,0){490}}

--- a/src/Hydra/Protocol/Figures/offchain-protocol.tex
+++ b/src/Hydra/Protocol/Figures/offchain-protocol.tex
@@ -8,21 +8,22 @@
 			%%% Initializing the head
 			\begin{tabular}{cc}
 				\adjustbox{valign=t,scale=\sfact}{
-					\begin{walgo}{0.6}
+					\begin{walgo}{0.7}
 						%%% INIT
 						\On{$(\hpInit)$ from client}{
 							$n \gets |\hydraKeys^{setup}|$ \;
 							$\hydraKeysAgg \gets \msCombVK(\hydraKeys^{setup})$ \;
 							$\cardanoKeys \gets \cardanoKeys^{setup}$\;
-							$\cPer \gets \cPer^{setup}$ \;
-							$\PostTx{}~(\mtxInit, \nop, \hydraKeysAgg,\cardanoKeys,\cPer)$ \;
+							$\Tcontest \gets \Tcontest^{setup}$ \;
+							\red{$\Tdeposit \gets \Tdeposit^{setup}$ \;}
+							$\PostTx{}~(\mtxInit, \nop, \hydraKeysAgg,\cardanoKeys,\Tcontest)$ \;
 						}
 						\vspace{12pt}
 
-						\On{$(\gcChainInitial, \cid, \seed, \nop, \hydraKeysAgg, \cardanoKeys^{\#}, \cPer)$ from chain}{
+						\On{$(\gcChainInitial, \cid, \seed, \nop, \hydraKeysAgg, \cardanoKeys^{\#}, \Tcontest)$ from chain}{
 						\Req{} $\hydraKeysAgg=\msCombVK(\hydraKeys^{setup})$\;
 						\Req{} $\cardanoKeys^{\#}= [ \hash(k)~|~\forall k \in \cardanoKeys^{setup}]$\;
-						\Req{} $\cPer=\cPer^{setup}$\;
+						\Req{} $\Tcontest=\Tcontest^{setup}$\;
 						\Req{} $\cid = \hash(\muHead(\seed))$ \;
 						}
 					\end{walgo}
@@ -51,7 +52,8 @@
 							$\hatv, \hats \gets 0$ \;
 							$\hatmT \gets \emptyset$ \;
 							$\tx_\omega \gets \bot$ \;
-							$U_\alpha \gets \emptyset$ \;
+							% NOTE: Actually a tx id, but does not matter
+							\red{$\tx_\alpha \gets \bot$ \;}
 						}
 
 					\end{walgo}
@@ -74,7 +76,7 @@
 								$\hatmT \gets \hatmT \cup \{\tx\}$ \;
 								% issue snapshot if we are leader
 								\If{$\hats = \bar{\mc S}.s \land \hpLdr(\bar{\mc S}.s + 1) = i$}{
-									\Multi{} $(\hpRS,\hatv,\bar{\mc S}.s+1,\hatmT, \red{\tx^\#_\alpha}, \tx_\omega)$ \;
+									\Multi{} $(\hpRS,\hatv,\bar{\mc S}.s+1,\hatmT, \red{\tx_\alpha}, \tx_\omega)$ \;
 								}
 							}
 						}
@@ -99,9 +101,11 @@
 							\Wait{$\hats = \bar{\mc S}.s \red{~ \land ~ v = \hatv}$}{
 								\Req{$\tx_\omega = \bot ~ \red{\lor ~ \tx_\alpha = \bot}$} \;
 								\blue{
+								  \If{$\tx_\alpha \neq \bot$}{
 									TODO: require consistent with $\bar{\mc S}$ \;
 									\Req{$\bar{\mc S}.U \applytx \tx_\omega \not= \bot$} \;
 									$U_{\mathsf{active}} \gets \bar{\mc S}.U \applytx \tx_\omega \setminus \mathsf{outputs}(\tx_\omega)$ \;
+								  }
 								}
 								\red{
 								  \If{$\tx_\alpha \neq \bot$}{
@@ -179,7 +183,7 @@
 
 									% issue snapshot if we are leader
 									\If{$\hpLdr(s+1) = i \land \hatmT \neq \emptyset$}{
-										\Multi{} $(\hpRS,\hatv,\bar{\mc S}.s+1, \hatmT , \red{\tx^\#_\alpha}, \tx_\omega)$ \;
+										\Multi{} $(\hpRS,\hatv,\bar{\mc S}.s+1, \hatmT , \red{\tx_\alpha}, \tx_\omega)$ \;
 									}
 								}
 							}
@@ -187,15 +191,15 @@
 						\vspace{12pt}
 
 						%%% DEPOSIT
-					    \On{$(\mathtt{depositTx}, \red{\tx^{\#}_{\alpha}, U, t_{\mathsf{created}}, t_{\mathsf{deadline}}})$ from chain}{
-						  \red{$\mathcal{D} \gets \mathcal{D} \cup (\tx^{\#}_{\alpha}, \mathsf{depositObj}(U, t_{\mathsf{created}}, t_{\mathsf{deadline}}, \mathsf{Inactive}))$}
+					    \On{$(\mathtt{depositTx}, \red{\tx_{\alpha}, U, t_{\mathsf{created}}, t_{\mathsf{deadline}}})$ from chain}{
+						  \red{$\mathcal{D} \gets \mathcal{D} \cup (\tx_{\alpha}, \mathsf{depositObj}(U, t_{\mathsf{created}}, t_{\mathsf{deadline}}, \mathsf{Inactive}))$}
 					    }
 						\vspace{12pt}
 
 						%%% RECOVER
 						\red{
-					    \On{$(\mathtt{recoverTx}, \tx^{\#}_{\alpha})$ from chain}{
-						  \red{$\mathcal{D} \gets \mathcal{D} \setminus (\tx^{\#}_{\alpha}, \cdot)$}
+					    \On{$(\mathtt{recoverTx}, \tx_{\alpha})$ from chain}{
+						  \red{$\mathcal{D} \gets \mathcal{D} \setminus (\tx_{\alpha}, \cdot)$}
 					    }
 						}
 						\vspace{12pt}
@@ -210,7 +214,7 @@
 						%%% INCREMENT
 						\On{$(\mathtt{incrementTx}, U, v)$ from chain}{
 							$\hatv \gets v$ \;
-							$\red{\tx^{\#}_\alpha \gets \bot}$\;
+							$\red{\tx_\alpha \gets \bot}$\;
 							$\hatmL \gets \hatmL \cup U$ \;
 						}
 						\vspace{12pt}
@@ -219,13 +223,17 @@
 						\red{
 						\On{$(\mathtt{tick}, t)$ from chain}{
 							\For{$D \in \mathcal{D}$}{
-							    $D.status \gets TODO$
+							  \If{$t > D.\mathsf{deadline} - T_{\mathsf{deposit}} $}{
+							    $D.\mathsf{status} \gets \mathsf{Expired}$
+							  }
+							  \ElseIf{$t > D.\mathsf{created} + T_{\mathsf{deposit}} $}{
+							    $D.\mathsf{status} \gets \mathsf{Active}$
+							  }
 							}
-							\If{$\exists D \in \mathcal{D} : D.status = \mathsf{Active}$}{
+							\If{$\exists D \in \mathcal{D} : D.\mathsf{status} = \mathsf{Active}$}{
 								% issue snapshot if we are leader
-								% FIXME: \tx^\#_\alpha undefined
-								\If{$\tx^\#_\alpha \neq \bot \land \tx_\omega = \bot \land \hats = \bar{\mc S}.s \land \hpLdr(\bar{\mc S}.s + 1) = i$}{
-									\Multi{} $(\hpRS,\hatv,\bar{\mc S}.s+1,\hatmT, \tx^\#_\alpha, \bot)$ \;
+								\If{$\tx_\alpha \neq \bot \land \tx_\omega = \bot \land \hats = \bar{\mc S}.s \land \hpLdr(\bar{\mc S}.s + 1) = i$}{
+									\Multi{} $(\hpRS,\hatv,\bar{\mc S}.s+1,\hatmT, \tx_\alpha, \bot)$ \;
 								}
 							}
 						}

--- a/src/Hydra/Protocol/Figures/offchain-protocol.tex
+++ b/src/Hydra/Protocol/Figures/offchain-protocol.tex
@@ -48,7 +48,7 @@
 							$\Uinit \gets \bigcup_{j=1}^{n} U_j$ \;
 							% $\Out~(\hpSnap,(0,U_0))$ \;
 							$\hatmL \gets \Uinit$ \;
-							$\bar{\mc S} \gets \blue{\Sno(0, 0, [], \Uinit, \emptyset , \emptyset)}$ \;
+							$\bar{\mc S} \gets \Sno(0, 0, [], \Uinit, \emptyset , \emptyset)$ \;
 							$\hatv, \hats \gets 0$ \;
 							$\hatmT \gets \emptyset$ \;
 							$\tx_\omega \gets \bot$ \;
@@ -98,23 +98,34 @@
 						%%% REQ SN
 						\On{$(\hpRS,v,s,\underline{\tx}_{\mathsf{req}} , \red{\tx_\alpha}, \tx_\omega)$ from $\party_j$}{
 							\Req{$v = \hatv ~ \land ~ s = \hats + 1 ~ \land ~ \hpLdr(s) = j$} \;
-							\Wait{$\hats = \bar{\mc S}.s \red{~ \land ~ v = \hatv}$}{
+							\Wait{$\hats = \bar{\mc S}.s \blue{~ \land ~ v = \hatv}$}{
 								\Req{$\tx_\omega = \bot ~ \red{\lor ~ \tx_\alpha = \bot}$} \;
-								\blue{
-								  \If{$\tx_\alpha \neq \bot$}{
-									TODO: require consistent with $\bar{\mc S}$ \;
-									\Req{$\bar{\mc S}.U \applytx \tx_\omega \not= \bot$} \;
+								\If{$\tx_\omega \neq \bot$}{
+								  % NOTE: require withdrawal to be stay consistent with last confirmed snapshot until cleared through a decrement
+								  \blue{
+								  \If{$v = \bar{\mc S}.v \land \bar{\mc S}.U_{\omega} \neq \bot$}{
+									\Req{$\bar{\mc S}.U_{\omega} = \mathsf{outputs}(\tx_\omega) $} \;
+								  }}
+								  \Else{
+									\Req{$\bar{\mc S}.U \applytx \tx_\omega \ne \bot$} \;
 									$U_{\mathsf{active}} \gets \bar{\mc S}.U \applytx \tx_\omega \setminus \mathsf{outputs}(\tx_\omega)$ \;
 								  }
 								}
-								\red{
-								  \If{$\tx_\alpha \neq \bot$}{
+								\If{\blue{$\tx_\alpha \neq \bot$}}{
+								  \red{
 									$\mathcal{D} \gets \mathcal{D}[\tx_\alpha]$ \;
-                                    \Req{$\mathcal{D}.\mathsf{status} \neq \mathsf{Expired}$} \;
-                                    \Wait{$\mathcal{D}.\mathsf{status} = \mathsf{Active}$}{
-									  TODO: require consistent with $\bar{\mc S}$ \;
-									  $U_\alpha \gets \mathcal{D}.U$ \;
-                                      $U_{\mathsf{active}} \gets U_{\mathsf{active}} \cup  U_{\alpha}$ \;
+									\Req{$\mathcal{D}.\mathsf{status} \neq \mathsf{Expired}$} \;
+								  }
+								  \Wait{\red{$\mathcal{D}.\mathsf{status} = \mathsf{Active}$}}{
+									% NOTE: require deposit to be stay consistent with last confirmed snapshot until cleared through an increment
+									\blue{
+									\If{$v = \bar{\mc S}.v \land \bar{\mc S}.U_{\alpha} \neq \bot$}{
+									  \Req{$\bar{\mc S}.U_{\alpha} = \red{\mathcal{D}.U} $} \;
+									}}
+									\Else{
+									  $U_\alpha \gets \red{\mathcal{D}.U}$ \;
+
+									  $U_{\mathsf{active}} \gets U_{\mathsf{active}} \cup  U_{\alpha}$ \;
 									}
 								  }
 								}
@@ -166,9 +177,9 @@
 									% NOTE: Implementation differs here and
 									% below as it stores seen version in seen
 									% snapshot and uses that to verify
-									\Req{} $\msVfy(\hydraKeysAgg, (\cid || \blue{\hatv ||} \hats || \eta || \eta_\alpha || \eta_\omega), \msCSig)$ \;
+									\Req{} $\msVfy(\hydraKeysAgg, (\cid || \hatv || \hats || \eta || \eta_\alpha || \eta_\omega), \msCSig)$ \;
 									% create confirmed snapshot for later reference
-									\blue{$\bar{\mc S} \gets \Sno(\hatv, \hats, \hatmT, \hatmU, U_\alpha, U_\omega)$ \;}
+									$\bar{\mc S} \gets \Sno(\hatv, \hats, \hatmT, \hatmU, U_\alpha, U_\omega)$ \;
 									$\bar{\mc S}.\sigma \gets \msCSig$ \;
 									%$\Out~(\hpSnap,(\bar{\mc S}.s,\bar{\mc S}.U))$ \;
 									$\forall \tx \in \mT_{\mathsf{req}} : \Out (\hpConf,\tx)$ \;

--- a/src/Hydra/Protocol/OffChain.tex
+++ b/src/Hydra/Protocol/OffChain.tex
@@ -141,7 +141,7 @@ party's local state consists of the following variables:
 to exchange and agree on protocol parameters during the protocol setup phase
 (see Section~\ref{sec:setup}), so we can assume the public Cardano keys
 $\cardanoKeys^{setup}$, Hydra keys $\hydraKeysAgg^{setup}$, as well as the
-contestation period $\cPer^{setup}$ are available. One of the clients then can
+contestation period $\Tcontest^{setup}$ are available. One of the clients then can
 start head initialization using the $\hpInit$ command, which will result in an
 $\mtxInit$ transaction being posted. \\
 

--- a/src/Hydra/Protocol/OffChain.tex
+++ b/src/Hydra/Protocol/OffChain.tex
@@ -11,20 +11,26 @@ head members, parties or simply protocol actors. The protocol is specified as a
 reactive system that processes three kinds of inputs:
 \begin{enumerate}
   \item On-chain protocol transactions as introduced in
-  Section~\ref{sec:on-chain}, which are posted to the mainchain and can be
-  observed by all actors:
-  \begin{itemize}
-    \item $\mathtt{initialTx}$: initiates a head
-    \item $\mathtt{commitTx}$: commits UTxO to an initializing head
-    \item $\mathtt{collectComTx}$: opens a head
-    \item $\mathtt{depositTx}$: prepares UTxO to be incremented
-    \item $\mathtt{incrementTx}$: adds UTxO to an open head
-    \item $\mathtt{decrementTx}$: removes UTxO from an open head
-    \item $\mathtt{closeTx}$: closes a head
-    \item $\mathtt{contestTx}$: contests a closed head
-    % NOTE: fanout not mentioned because not needed in off-chain protocol
-    % description
-  \end{itemize}
+        Section~\ref{sec:on-chain}, which are posted to the mainchain and can be
+        observed by all actors:
+        \begin{itemize}
+          \item $\mathtt{initialTx}$: initiates a head
+          \item $\mathtt{commitTx}$: commits UTxO to an initializing head
+          \item $\mathtt{collectComTx}$: opens a head
+          \item $\mathtt{depositTx}$: some UTxO was deposited to be incremented
+          \item $\mathtt{recoverTx}$: deposited UTxO was recovered
+          \item $\mathtt{incrementTx}$: adds UTxO to an open head
+          \item $\mathtt{decrementTx}$: removes UTxO from an open head
+          \item $\mathtt{closeTx}$: closes a head
+          \item $\mathtt{contestTx}$: contests a closed head
+          % NOTE: fanout not mentioned because not needed in off-chain protocol
+          % description
+        \end{itemize}
+        Also, a special input when time advanced on chain may be used:
+        \begin{itemize}
+          \item $\mathtt{tick}$: time advanced on chain
+        \end{itemize}
+  
   \item Off-chain network messages sent between protocol actors (parties):
   \begin{itemize}
     \item $\hpRT$: to request a transaction to be included in the next snapshot
@@ -57,9 +63,7 @@ off-chain protocol logic relies on these assumptions:
         for individual messages. Unauthenticated messages must be dropped.
   \item The head protocol gets correctly (and with completeness) notified about
         observed transactions on-chain belonging to the respective head
-        instance.~\red{Observation may be delayed varying by type of
-        transaction. See~\ref{sec:rollbacks} for a discussion on eventual
-        consistency of transactions.}
+        instance.
   \item All inputs are processed to completion, i.e.\ run-to-completion
         semantics and no preemption.
   \item Inputs are deduplicated. That is, any two identical inputs must not lead
@@ -114,9 +118,14 @@ party's local state consists of the following variables:
         applying $\hatmT$ to $\bar{S}.U$ to validate requested transactions.
   \item $\hatmT \in \mT^{*}$: List of transactions applied locally and pending
         inclusion in a snapshot (if this party is the next leader).
-  \item $U_\alpha \in {(\txInputs \times \txOutputs)}^{*}$: UTxO set pending to be added to the head.
+  \item $\tx_\alpha \in \mathcal{T}$: Pending deposit transaction\footnote{In
+        fact this would only need to be a transaction id to look up the
+        corresponding deposit in $\mc D$} to be used for incrementing the head
+        state.
   \item $\tx_\omega \in \mathcal{T}$: Pending decrement transaction, whose outputs are to be
         withdrawn from the head.
+  \item $\mc D$: Set of deposit objects tracking deposit transactions with their
+        status.
   \item $\bar{\mc S}$: Snapshot object of the latest confirmed snapshot which
         contains:
         \begin{center}
@@ -130,8 +139,14 @@ party's local state consists of the following variables:
             $\bar{\mc S}.\sigma$         & multisignature \\ \hline
           \end{tabular}
         \end{center}
-        where constructor $\Sno(v,n,\mT,U,U_\alpha, U_\omega)$ initializes a new snapshot object with $\bar{\mc S}.\sigma = \emptyset$.
 \end{itemize}
+
+where constructor $\text{snObj}(v, n, T, U, U_\alpha, U_\omega)$ initializes a
+new snapshot object with $\bar{\mathcal{S}}.\sigma = \emptyset$. \\
+
+Additionally, deposit objects are created using
+$\text{depositObj}(U, t_{\text{created}}, t_{\text{deadline}}, \text{status})$
+where status can be $\text{Inactive}$, $\text{Active}$, or $\text{Expired}$.
 
 \subsection{Protocol flow}
 
@@ -141,15 +156,17 @@ party's local state consists of the following variables:
 to exchange and agree on protocol parameters during the protocol setup phase
 (see Section~\ref{sec:setup}), so we can assume the public Cardano keys
 $\cardanoKeys^{setup}$, Hydra keys $\hydraKeysAgg^{setup}$, as well as the
-contestation period $\Tcontest^{setup}$ are available. One of the clients then can
-start head initialization using the $\hpInit$ command, which will result in an
-$\mtxInit$ transaction being posted. \\
+contestation period $\Tcontest^{setup}$ are available. One of the clients then
+can start head initialization using the $\hpInit$ command, which will result in
+an $\mtxInit$ transaction being posted. Not strictly a protocol parameter, but
+the deposit period $\Tdeposit$ would also be made available from
+configuration.\\
 
 \dparagraph{$\mathtt{initialTx}$.}\quad All parties will receive this $\mtxInit$
 transaction and validate announced parameters against the pre-agreed $setup$
 parameters, as well as the structure of the transaction and the minting policy
-used. This is a vital step to ensure the initialized Head is valid, which
-cannot be checked completely on-chain (see also Section~\ref{sec:init-tx}). \\
+used. This is a vital step to ensure the initialized Head is valid, which cannot
+be checked completely on-chain (see also Section~\ref{sec:init-tx}). \\
 
 \dparagraph{$\mathtt{commitTx}$.}\quad As each party $p_{j}$ posts a
 $\mtxCommit$ transaction, the protocol records observed committed UTxOs of each
@@ -161,12 +178,13 @@ spending. Should any party want to abort, they would post an $\mtxAbort$
 transaction and the protocol would end at this point.\\
 
 \dparagraph{$\mathtt{collectComTx}$.}\quad Upon observing the $\mtxCollect$
-transaction, the parties compute $\Uinit \gets \bigcup_{j=1}^{n} C_j$ using previously
-observed $C_j$ and initialize $\hatmL = \Uinit$. The seen transaction set is
-initialized empty $\hatmT = \emptyset$, seen head state version $\hatv = 0$, as well as
-snapshot number $\hats = 0$. No UTxO to increment $U_{\alpha} = \emptyset$ and no
-decrement transaction $\tx_{\omega} = \bot$ is pending, and the last confirmed snapshot
-is initialized accordingly $\bar{\mc S} \gets \blue{\Sno(0, 0, [], \Uinit, \emptyset, \emptyset)}$.
+transaction, the parties compute $\Uinit \gets \bigcup_{j=1}^{n} C_j$ using
+previously observed $C_j$ and initialize $\hatmL = \Uinit$. The seen transaction
+set is initialized empty $\hatmT = \emptyset$, seen head state version
+$\hatv = 0$, as well as snapshot number $\hats = 0$. No deposit transaction
+$\tx_{\alpha} = \bot$ and no decrement transaction $\tx_{\omega} = \bot$ are
+pending, and the last confirmed snapshot is initialized accordingly
+$\bar{\mc S} \gets \blue{\Sno(0, 0, [], \Uinit, \emptyset, \emptyset)}$.
 
 \subsubsection{Processing transactions off-chain}
 
@@ -178,61 +196,79 @@ While the frequency of snapshots in the general Head protocol~\cite{hydrahead20}
 was configurable, the Coordinated Head protocol does specify a snapshot to be
 created after each transaction.\\
 
-\dparagraph{$\hpRT$.}\quad Upon receiving request $(\hpRT,\tx)$, the transaction is
-applied to the \emph{local} ledger state $\hatmL \applytx \tx$. If not
+\dparagraph{$\hpRT$.}\quad Upon receiving request $(\hpRT,\tx)$, the transaction
+is applied to the \emph{local} ledger state $\hatmL \applytx \tx$. If not
 applicable yet, the protocol does $\KwWait$ to retry later or eventually marks
 this transaction as invalid (see assumption about events piling up). After
-applying and if there is no current snapshot in flight ($\hats = \bar{\mc S}.s$) and the
-receiving party $\party_{i}$ is the next snapshot
-leader, a message to request snapshot signatures $\hpRS$ is sent. \\
-
-\dparagraph{$\hpRD$.}\quad Upon receiving request $(\hpRD,\tx_\omega)$, the transaction
-is checked against the \emph{local} ledger state and if it is not applicable yet
-or another commit or decommit is pending still, the protocol does $\KwWait$ to
-retry later or eventually marks the decommit as invalid. After applying $\tx$,
-its outputs are removed from \emph{local} ledger state $\hatmL$ so that they are
-not available any more and the decommit transaction is kept in the local state
-($\tx_\omega$). If there is no current snapshot in flight ($\hats = \bar{\mc S}.s$)
+applying and if there is no current snapshot in flight ($\hats = \bar{\mc S}.s$)
 and the receiving party $\party_{i}$ is the next snapshot leader, a message to
-request snapshot signatures $\hpRS$ containing the decrement transaction $\tx_\omega$ is sent. \\
+request snapshot signatures $\hpRS$ is sent. \\
 
-\dparagraph{$\mathtt{depositTx}$.}\quad Upon observing a \mtxDeposit{}
-  transaction as settled\footnote{Protocol actors might use different techniques
-    and delays to determine transaction finality. See also~\ref{sec:rollbacks}.}
-  and no other commit or decommit is pending still, each party keeps track of
-  the observed deposited UTxO as the pending increment UTxO set $U_{\alpha} = U$. If
-  other commits or decommits are pending, the protocol $\KwWait$s and retries
-  updating state later.\todo{smelly and fragile} If the observing party is the
-  next snapshot leader, it may request a new snapshot by sending a $\hpRS$
-  including the UTxO to increment $U_{\alpha}$.  \\
+\dparagraph{$\hpRD$.}\quad Upon receiving request $(\hpRD,\tx_\omega)$, the
+transaction is checked against the \emph{local} ledger state and if it is not
+applicable yet or another commit or decommit is pending still, the protocol does
+$\KwWait$ to retry later or eventually marks the decommit as invalid. After
+applying $\tx$, its outputs are removed from \emph{local} ledger state $\hatmL$
+so that they are not available any more and the decommit transaction is kept in
+the local state ($\tx_\omega$). If there is no current snapshot in flight
+($\hats = \bar{\mc S}.s$) and the receiving party $\party_{i}$ is the next
+snapshot leader, a message to request snapshot signatures $\hpRS$ containing the
+decrement transaction $\tx_\omega$ is sent. \\
+
+\dparagraph{$\mathtt{depositTx}$.}\quad Upon observing a deposit transaction,
+each party records the deposit index by deposit transaction id to their local
+deposit registry $\mathcal{D}$ with status $\text{Inactive}$. The deposit
+contains deposited UTxO $U$, creation time $t_{\text{created}}$, and deadline
+$t_{\text{deadline}}$. \\
+
+\dparagraph{$\mathtt{recoverTx}$.}\quad Upon observing a recover transaction,
+each party drops the corresponding entry from its deposit registry
+$\mathcal{D}$. \\
+
+\dparagraph{$\mathtt{tick}$.}\quad Whenever time advances (on-chain) to point
+$t$, parties update the status of deposits in $\mathcal{D}$ accordingly using
+the configured deposit period $\Tdeposit$:
+\begin{itemize}
+  \item $\mathsf{Expired}$ when deadline passed (or too soon): $t > t_{\text{deadline}} - \Tdeposit$
+  \item $\mathsf{Active}$ when deposit settled enougth: $t > t_{\text{created}} + \Tdeposit$
+\end{itemize}
+When deposits become $\mathsf{Active}$ and no other commit / decommit is
+pending, and the party is the next snapshot leader, it may request a new
+snapshot including the deposit transaction $\tx_{\alpha}$. \\
 
 \dparagraph{$\hpRS$.}\quad Upon receiving request
-$(\hpRS,v,s,\underline{\tx}_{\mathsf{req}}, U_\alpha, \tx_\omega)$\footnote{Snapshot
+$(\hpRS,v,s,\underline{\tx}_{\mathsf{req}}, \tx_\alpha, \tx_\omega)$\footnote{Snapshot
   requests with only transaction identifiers and output references are possible
   if all parties keep an index of previously seen transactions and their
-  identifiers.} from party $\party_j$, the receiving $\party_i$ $\Req$s
-  that only a commit or decommit is currently pending, and that $v$ refers
-to the current open state version, $s$ is the next snapshot number and that
-party $\party_j$ is responsible for leading its creation.\todo{define $\hpLdr$}
-Party $\party_i$ may has to $\KwWait$ until the previous snapshot is confirmed
-($\bar{\mc S}.s = \hats$). If the decommit transaction $\tx_{\omega}$ is not $\bot$, the
-transaction is $\Req$d to be applicable to the last confirmed UTxO set
-$\bar{\mc S}.U$ and decommitted transaction outputs must be removed, yielding
-the still active UTxO set $U_{\mathsf{active}}$. Then, all requested
-transactions $\underline{\tx}_{\mathsf{req}}$ are $\Req$d to be applicable to
-$U_{\mathsf{active}}$, otherwise the snapshot is rejected as invalid. Only then,
-$\party_i$ increments their seen-snapshot counter $\hats$, resets the signature
-accumulator $\hatSigma$, and computes the UTxO set of the new local snapshot as
+  identifiers.} from party $\party_j$, the receiving $\party_i$ $\Req$s that
+only a commit or decommit may be pending, and that $v$ refers to the current
+open state version, $s$ is the next snapshot number and that party $\party_j$ is
+responsible for leading its creation. Party $\party_i$ may have to wait until
+the previous snapshot is confirmed ($\bar{\mathcal{S}}.s = \hat{s}$).
+Furthermore, the protocol validates the snapshot request by:
+\begin{enumerate}
+  \item If a decommit is requested: verify the transaction is applicable to the
+        last confirmed UTxO set and update the active utxo set with it
+  \item If a deposit/commit is requested: verify the corresponding deposit is
+        $\text{Active}$ and update the active utxo set with it
+  \item If we are on the same version as the last snapshot, any requested
+        decommit or commit must match the last snapshot.
+  \item Verify all requested transactions $\underline{\tx}_{\mathsf{req}}$ are
+        applicable to the active UTxO set
+\end{enumerate}
+Only then, $\party_i$ increments their seen-snapshot counter $\hats$, resets the
+signature accumulator $\hatSigma$, and computes the UTxO set of the new local
+snapshot as
 $U \gets U_{\mathsf{active}} \applytx \underline{\tx}_{\mathsf{req}}$. Then,
 $\party_i$ creates a signature $\msSig_i$ using their signing key
 $\hydraSigningKey$ on a message comprised by the $\cid$, the new snapshot number
 $\hats$, the new $\eta$ resulting from canonically combining $U$ (see
-Section~\ref{sec:close-tx} for details), and either $\eta_{\alpha}$ or $\eta_{\omega}$ derived
-from commit UTxO $U_{\alpha}$ or decommit transaction $\tx_{\omega}$ respectively. The
-signature is sent to all head members via message $(\hpAS,\hats,\msSig_i)$.
-Finally, the local ledger state $\hatmL$ and pending transaction set $\hatmT$
-get pruned by re-applying all locally pending transactions $\hatmT$ to the just
-requested snapshot's UTxO set iteratively and
+Section~\ref{sec:close-tx} for details), and either $\eta_{\alpha}$ or
+$\eta_{\omega}$ derived from deposited $U_{\alpha}$ or decommit transaction
+$\tx_{\omega}$ respectively. The signature is sent to all head members via
+message $(\hpAS,\hats,\msSig_i)$. Finally, the local ledger state $\hatmL$ and
+pending transaction set $\hatmT$ get pruned by re-applying all locally pending
+transactions $\hatmT$ to the just requested snapshot's UTxO set iteratively and
 ultimately yielding a ``pruned'' version of $\hatmT$ and $\hatmL$. \\
 
 \dparagraph{$\hpAS$.}\quad Upon receiving acknowledgment $(\hpAS,s,\msSig_j)$, all
@@ -291,7 +327,6 @@ and certificate $\xi$ is constructed and posted in a \mtxContest{} transaction (
 Section~\ref{sec:contest-tx}).
 
 \subsection{Rollbacks and protocol changes}\label{sec:rollbacks}
-\todo{Explain varying finality of deposit vs. increment}
 \todo{Explain why rollbacks are no problem to increment/decrement}
 \todo{Write about contestation deadline vs. rollbacks}
 
@@ -348,7 +383,7 @@ $\mtxCommit$ transactions were rolled back, a bad actor could choose to commit a
 different UTxO and open the Head with a different initial UTxO set, while the
 already signed snapshots would still be (cryptographically) valid. To mitigate
 this, all signatures on snapshots need to incorporate the initial UTxO set by
-including $\eta_{0}$. \todo{version-counting is less powerfull}
+including $\eta_{0}$.\todo{not implemented and maybe redundant with directly open heads}
 
 \input{Hydra/Protocol/Figures/offchain-protocol}
 

--- a/src/Hydra/Protocol/OnChain.tex
+++ b/src/Hydra/Protocol/OnChain.tex
@@ -87,7 +87,7 @@ by a single output reference parameter $\seed \in \tyOutRef$:
   $o_{\mathsf{head}}$, which captures
   the initial state of the protocol in the datum
   \[
-	\datumHead = (\stInitial,\cid',\seed',\hydraKeys,\cPer)
+	\datumHead = (\stInitial,\cid',\seed',\hydraKeys,\Tcontest)
   \]
   where
   \begin{mitemize}
@@ -96,7 +96,7 @@ by a single output reference parameter $\seed \in \tyOutRef$:
 	\item $\seed'$ is the output reference parameter of $\muHead$,
 	\item $\hydraKeys$ are the off-chain multi-signature keys from the setup
 	phase,
-	\item $\cPer$ is the contestation period.
+	\item $\Tcontest$ is the contestation period.
   \end{mitemize}
 \end{itemize}
 
@@ -224,7 +224,7 @@ reimburse, and checks:
   \item State is advanced from $\datumHead \sim \stInitial$ to terminal state
   $\stFinal$:
   \[
-	(\stInitial,\cid,\seed,\hydraKeys,\cPer) \xrightarrow[m]{\stAbort} \stFinal.
+	(\stInitial,\cid,\seed,\hydraKeys,\Tcontest) \xrightarrow[m]{\stAbort} \stFinal.
   \]
   \item All UTxOs committed into the head are reimbursed exactly as they were
   committed. This is done by comparing hashes of serialised representations of
@@ -267,10 +267,10 @@ all the committed UTxOs to the same head. It has
 $\redeemerHead = \mathsf{collect}$ and checks:
 \begin{menumerate}
   \item State is advanced from $\datumHead \sim \stInitial$ to
-  $\datumHead' \sim \stOpen$, parameters $\cid,\hydraKeys,\cPer$ stay
+  $\datumHead' \sim \stOpen$, parameters $\cid,\hydraKeys,\Tcontest$ stay
   unchanged and the new state is governed again by $\nuHead$
   \[
-	(\stInitial,\cid,\seed,\hydraKeys,\cPer) \xrightarrow{\stCollect} (\stOpen,\cid,\hydraKeys,\cPer,v,\eta)
+	(\stInitial,\cid,\seed,\hydraKeys,\Tcontest) \xrightarrow{\stCollect} (\stOpen,\cid,\hydraKeys,\Tcontest,v,\eta)
   \]
   where snapshot version is initialized as $v = 0$.
   \item Commits are collected in $\eta$
@@ -445,10 +445,10 @@ $\txOutRef_{\mathsf{deposit}}$ points to the claimed deposit. The validator
 checks:
 \begin{menumerate}
   \item State is advanced from $\datumHead \sim \stOpen$ to
-  $\datumHead' \sim \stOpen$, parameters $\cid,\hydraKeysAgg,\nop,\cPer$
+  $\datumHead' \sim \stOpen$, parameters $\cid,\hydraKeysAgg,\nop,\Tcontest$
   stay unchanged and the new state is governed again by $\nuHead$:
   \[
-	(\stOpen,\cid,\hydraKeysAgg,\nop,\cPer,v,\eta) \xrightarrow[\xi, s, \txOutRef_{\mathsf{increment}}]{\mathsf{increment}} (\stOpen,\cid,\hydraKeysAgg,\nop,\cPer,v',\eta')
+	(\stOpen,\cid,\hydraKeysAgg,\nop,\Tcontest,v,\eta) \xrightarrow[\xi, s, \txOutRef_{\mathsf{increment}}]{\mathsf{increment}} (\stOpen,\cid,\hydraKeysAgg,\nop,\Tcontest,v',\eta')
   \]
   \item New version $v'$ is incremented correctly
   \[
@@ -504,10 +504,10 @@ used snapshot number and $m$ is the number of outputs to distribute. The
 validator checks:
 \begin{menumerate}
   \item State is advanced from $\datumHead \sim \stOpen$ to
-  $\datumHead' \sim \stOpen$, parameters $\cid,\hydraKeys,\cPer$ stay
+  $\datumHead' \sim \stOpen$, parameters $\cid,\hydraKeys,\Tcontest$ stay
   unchanged and the new state is governed again by $\nuHead$
   \[
-	(\stOpen,\cid,\hydraKeys,\cPer,v,\eta) \xrightarrow[\xi, s, m]{\mathsf{decrement}} (\stOpen,\cid,\hydraKeys,\cPer,v',\eta')
+	(\stOpen,\cid,\hydraKeys,\Tcontest,v,\eta) \xrightarrow[\xi, s, m]{\mathsf{decrement}} (\stOpen,\cid,\hydraKeys,\Tcontest,v',\eta')
   \]
   \item New version $v'$ is incremented correctly
   \[
@@ -559,10 +559,10 @@ $\redeemerHead = (\mathsf{close}, \mathsf{CloseType})$, where
 $\mathsf{CloseType}$ is a hint against which open state to close and checks:
 \begin{menumerate}
   \item State is advanced from $\datumHead \sim \stOpen$ to
-  $\datumHead' \sim \stClosed$, parameters $\cid,\hydraKeys,\cPer$
+  $\datumHead' \sim \stClosed$, parameters $\cid,\hydraKeys,\Tcontest$
   stay unchanged and the new state is governed again by $\nuHead$
   \[
-	(\stOpen,\cid,\hydraKeys,\cPer,v,\eta) \xrightarrow[\mathsf{CloseType}]{\stClose} (\stClosed,\cid,\hydraKeys,\cPer,v',s',\eta', \eta_\alpha\Delta', \eta_\omega\Delta', \contesters,\Tfinal)
+	(\stOpen,\cid,\hydraKeys,\Tcontest,v,\eta) \xrightarrow[\mathsf{CloseType}]{\stClose} (\stClosed,\cid,\hydraKeys,\Tcontest,v',s',\eta', \eta_\alpha\Delta', \eta_\omega\Delta', \contesters,\tfinal)
   \]
   \item Last known open state version is recorded in closed state
   \[
@@ -653,13 +653,13 @@ $\mathsf{CloseType}$ is a hint against which open state to close and checks:
 
   \item Correct contestation deadline is set
   \[
-	\Tfinal = \txValidityMax + T
+	\tfinal = \txValidityMax + T
   \]
   \item Transaction validity range is bounded by
   \[
 	\txValidityMax - \txValidityMin \leq T
   \]
-  to ensure the contestation deadline $\Tfinal$ is at most $2*T$ in the future.
+  to ensure the contestation deadline $\tfinal$ is at most $2*T$ in the future.
   \item Value in the head is preserved
   \[
 	\valHead' = \valHead
@@ -696,10 +696,10 @@ $\redeemerHead = (\mathsf{contest}, \mathsf{ContestType})$, where
 $\mathsf{ContestType}$ is a hint how to verify the snapshot and checks:
 \begin{menumerate}
   \item State is advanced from $\datumHead \sim \stOpen$ to
-  $\datumHead' \sim \stClosed$, parameters $\cid,\hydraKeys,\cPer$
+  $\datumHead' \sim \stClosed$, parameters $\cid,\hydraKeys,\Tcontest$
   stay unchanged and the new state is governed again by $\nuHead$
   \[
-	(\stClosed,\cid,\hydraKeys,\cPer,v,s,\eta,\eta_\alpha\Delta,\eta_\omega\Delta,\contesters,\Tfinal) \xrightarrow[\mathsf{ContestType}]{\stContest} (\stClosed,\cid,\hydraKeys,\cPer,v',s',\eta',\eta_\alpha\Delta',\eta\omega\Delta',\contesters',\Tfinal')
+	(\stClosed,\cid,\hydraKeys,\Tcontest,v,s,\eta,\eta_\alpha\Delta,\eta_\omega\Delta,\contesters,\tfinal) \xrightarrow[\mathsf{ContestType}]{\stContest} (\stClosed,\cid,\hydraKeys,\Tcontest,v',s',\eta',\eta_\alpha\Delta',\eta\omega\Delta',\contesters',\tfinal')
   \]
 
   \item Last known open state version stays recorded in closed state
@@ -787,13 +787,13 @@ $\mathsf{ContestType}$ is a hint how to verify the snapshot and checks:
   \]
   \item Transaction is posted before deadline
   \[
-	\txValidityMax \leq \Tfinal
+	\txValidityMax \leq \tfinal
   \]
   \item Contestation deadline is updated correctly to
   \[
-	\Tfinal' = \left\{\begin{array}{ll}
-	  \Tfinal     & \mathrm{if} ~ |\contesters'| = n, \\
-	  \Tfinal + T & \mathrm{otherwise.}
+	\tfinal' = \left\{\begin{array}{ll}
+	  \tfinal     & \mathrm{if} ~ |\contesters'| = n, \\
+	  \tfinal + T & \mathrm{otherwise.}
 	\end{array}\right.
 \]
 \item Value in the head is preserved
@@ -837,7 +837,7 @@ outputs to distribute from the $\stClosed$ state, and checks:
   \item State is advanced from $\datumHead \sim \stClosed$ to terminal state
   $\stFinal$: % XXX: What does this actually mean?
   \[
-	(\stClosed,\cid,\hydraKeys,\cPer,v, s,\eta,\eta_\alpha\Delta,\eta_\omega\Delta,\contesters,\Tfinal) \xrightarrow[m,n,n']{\stFanout} \stFinal
+	(\stClosed,\cid,\hydraKeys,\Tcontest,v, s,\eta,\eta_\alpha\Delta,\eta_\omega\Delta,\contesters,\tfinal) \xrightarrow[m,n,n']{\stFanout} \stFinal
   \]
   \item The first $m$ outputs are distributing funds according to $\eta$. That is,
   the outputs exactly correspond to the UTxO canonically combined $U^{\#}$ (see
@@ -857,7 +857,7 @@ outputs to distribute from the $\stClosed$ state, and checks:
   \[
 	\eta_{\omega\Delta} = U^{\#}_{\omega\Delta} = \hash(\bigoplus_{j=m'}^{m+n'} \bytes(o_{j}))
   \]
-  \item Transaction is posted after contestation deadline $\txValidityMin > \Tfinal$.
+  \item Transaction is posted after contestation deadline $\txValidityMin > \tfinal$.
   \item All tokens are burnt
   $|\{\cid \mapsto \cdot \mapsto -1\} \in \txMint| = n + 1$.
 \end{menumerate}

--- a/src/Hydra/Protocol/Setup.tex
+++ b/src/Hydra/Protocol/Setup.tex
@@ -32,7 +32,7 @@ protocol parameters.
 
 	\item Each party establishes pairwise communication channels to all other parties. That is, every network message received from a specific party is checked for (channel) authentication. It is the implementer’s duty to find a suitable authentication process for the communication channels.
 
-	\item All parties agree on a contestation period $\cPer$.
+	\item All parties agree on a contestation period $\Tcontest$.
 \end{itemize}
 
 If any of the above fails (or the party does not agree to join the head in the

--- a/src/macros.tex
+++ b/src/macros.tex
@@ -117,8 +117,9 @@
 \newcommand{\tyValidity}{\mathcal{S}^{\leftrightarrow}} % type of validity intervals
 
 % other times and periods
-\newcommand{\cPer}{T}
-\newcommand{\Tfinal}{t_{\mathsf{final}}}
+\newcommand{\Tcontest}{T_\mathsf{contest}}
+\newcommand{\tfinal}{t_{\mathsf{final}}}
+\newcommand{\Tdeposit}{T_\mathsf{deposit}}
 
 \newcommand{\txIpend}{i_{\mathsf{pend}}}
 \newcommand{\txIpendSet}{I_{\mathsf{pend}}}


### PR DESCRIPTION
Changes to the off-chain protocol as motivated by https://github.com/cardano-scaling/hydra/pull/1978

- Updated the offchain chapter, including descriptions and figure with new deposit handling, but also the things that were missing/inconsistent from "recent" changes (https://github.com/cardano-scaling/hydra/pull/1540). Rendered commit ec504ef08e662e49b2cfb631010e7440b88e797b:
 
![image](https://github.com/user-attachments/assets/19e133e6-c7be-4472-91fc-a0ef54f94e9f)
